### PR TITLE
fix: player login reroute to choose clan

### DIFF
--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -75,7 +75,7 @@ export default function Login() {
             }
             // Redirect to player dashboard
             else if (data.role === "PLAYER") {
-                router.push("/find-tournament");
+                router.push("/choose-clan");
             }
         } catch (error) {
             console.error("Login failed", error);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated redirection logic for users after successful Google login based on their role.
		- Players are now redirected to `/choose-clan` instead of `/find-tournament`. 

- **Bug Fixes**
	- Ensured consistent user experience by refining the login flow without altering existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->